### PR TITLE
Made dependentAPI optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,13 @@ To install the <chart-name> chart:
 To uninstall the chart:
 
     helm delete <release name> -n components
+
+
+## Optional API Dependency
+
+The Product Catalog component can be installed with an option API dependency (for a downstream Product Catalog API). By default, this dependency is not enabled. You can enable it with:
+
+```
+helm install <release name> oda-components/productcatalog --set component.dependentAPIs.enabled=true -n components
+```
+

--- a/charts/ProductCatalog/Chart.yaml
+++ b/charts/ProductCatalog/Chart.yaml
@@ -15,7 +15,8 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.2.2
+version: 1.2.3
+# version: 1.2.3 - Made dependent APIs optional (enabled with --set component.dependentAPIs.enabled=true)
 # version: 1.2.2 - Added filter by componentName to dependent APIs
 # version: 1.2.1 - Bug fix for apiType on dependent APIs
 # version: 1.2.0 - Added the federation of downstream catalogs using dependent APIs

--- a/charts/ProductCatalog/templates/component-productcatalog.yaml
+++ b/charts/ProductCatalog/templates/component-productcatalog.yaml
@@ -36,9 +36,13 @@ spec:
       developerUI: /{{.Release.Name}}-{{.Values.component.name}}/tmf-api/promotionManagement/v4/docs
       port: 8080      
     dependentAPIs: 
+    {{- if .Values.component.dependentAPIs.enabled }}
     - name: downstreamproductcatalog 
       apiType: openapi     
       specification: https://raw.githubusercontent.com/tmforum-apis/TMF620_ProductCatalog/master/TMF620-ProductCatalog-v4.0.0.swagger.json
+    {{- else }}
+      []
+    {{- end }}
   eventNotification:
     publishedEvents: []
     subscribedEvents: []

--- a/charts/ProductCatalog/values.yaml
+++ b/charts/ProductCatalog/values.yaml
@@ -11,6 +11,8 @@ component:
   publicationDate: 2024-09-17T00:00:00.000Z
   version: "0.0.1"
   storageClassName: default
+  dependentAPIs:
+    enabled: false
 security:
   controllerRole: Admin
 mongodb:


### PR DESCRIPTION
The Product Catalog component can now be installed with an option API dependency (for a downstream Product Catalog API). By default, this dependency is not enabled. You can enable it with:

```
helm install <release name> oda-components/productcatalog --set component.dependentAPIs.enabled=true -n components
```