### PR TITLE
Added APi gateway policies in helm chart of PI and PC

### DIFF
--- a/charts/ProductCatalog/Chart.yaml
+++ b/charts/ProductCatalog/Chart.yaml
@@ -15,7 +15,8 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.2.5
+version: 1.2.6
+# version: 1.2.5 - added api gateway policies option to pass exposedapis policies using helm charts.
 # version: 1.2.5 - Self-signed certificates is an option in the helm chart: component.dependentAPIs.rejectUnauthorizedCertificates=false
 # version: 1.2.4 - Added dev environment workaround for localhost and self-signed certificates
 # version: 1.2.3 - Made dependent APIs optional (enabled with --set component.dependentAPIs.enabled=true)

--- a/charts/ProductCatalog/templates/component-productcatalog.yaml
+++ b/charts/ProductCatalog/templates/component-productcatalog.yaml
@@ -25,6 +25,12 @@ spec:
       specification: ["https://raw.githubusercontent.com/tmforum-apis/TMF620_ProductCatalog/master/TMF620-ProductCatalog-v4.0.0.swagger.json"]
       implementation: {{.Release.Name}}-prodcatapi
       apiType: openapi
+      apiKeyVerification: {{.Values.component.apipolicy.apiKeyVerification | toYaml | nindent 8}}
+      rateLimit: {{.Values.component.apipolicy.rateLimit | toYaml | nindent 8}}
+      quota: {{.Values.component.apipolicy.quota | toYaml | nindent 8}}
+      OASValidation: {{.Values.component.apipolicy.OASValidation | toYaml | nindent 8}}
+      CORS: {{.Values.component.apipolicy.CORS | toYaml | nindent 8}}
+      template: "{{.Values.component.apipolicy.template}}"
       path: /{{.Release.Name}}-{{.Values.component.name}}/tmf-api/productCatalogManagement/v4
       developerUI: /{{.Release.Name}}-{{.Values.component.name}}/tmf-api/productCatalogManagement/v4/docs
       port: 8080
@@ -32,6 +38,12 @@ spec:
       specification: ["https://raw.githubusercontent.com/tmforum-apis/TMF671_Promotion/master/TMF671-Promotion-v4.0.0.swagger.json"]
       implementation: {{.Release.Name}}-promgmtapi
       apiType: openapi
+      apiKeyVerification: {{.Values.component.apipolicy.apiKeyVerification | toYaml | nindent 8}}
+      rateLimit: {{.Values.component.apipolicy.rateLimit | toYaml | nindent 8}}
+      quota: {{.Values.component.apipolicy.quota | toYaml | nindent 8}}
+      OASValidation: {{.Values.component.apipolicy.OASValidation | toYaml | nindent 8}}
+      CORS: {{.Values.component.apipolicy.CORS | toYaml | nindent 8}}
+      template: "{{.Values.component.apipolicy.template}}"
       path: /{{.Release.Name}}-{{.Values.component.name}}/tmf-api/promotionManagement/v4
       developerUI: /{{.Release.Name}}-{{.Values.component.name}}/tmf-api/promotionManagement/v4/docs
       port: 8080      
@@ -50,6 +62,12 @@ spec:
     exposedAPIs: 
     - name: metrics
       apiType: prometheus
+      apiKeyVerification: {{.Values.component.apipolicy.apiKeyVerification | toYaml | nindent 8}}
+      rateLimit: {{.Values.component.apipolicy.rateLimit | toYaml | nindent 8}}
+      quota: {{.Values.component.apipolicy.quota | toYaml | nindent 8}}
+      OASValidation: {{.Values.component.apipolicy.OASValidation | toYaml | nindent 8}}
+      CORS: {{.Values.component.apipolicy.CORS | toYaml | nindent 8}}
+      template: "{{.Values.component.apipolicy.template}}"
       implementation: {{.Release.Name}}-{{.Values.component.name}}-sm
       path: /{{.Release.Name}}-{{.Values.component.name}}/metrics
       port: 4000    
@@ -60,6 +78,12 @@ spec:
       specification: ["https://raw.githubusercontent.com/tmforum-apis/TMF669_PartyRole/master/TMF669-PartyRole-v4.0.0.swagger.json"]
       implementation: {{.Release.Name}}-partyroleapi
       apiType: openapi
+      apiKeyVerification: {{.Values.component.apipolicy.apiKeyVerification | toYaml | nindent 8}}
+      rateLimit: {{.Values.component.apipolicy.rateLimit | toYaml | nindent 8}}
+      quota: {{.Values.component.apipolicy.quota | toYaml | nindent 8}}
+      OASValidation: {{.Values.component.apipolicy.OASValidation | toYaml | nindent 8}}
+      CORS: {{.Values.component.apipolicy.CORS | toYaml | nindent 8}}
+      template: "{{.Values.component.apipolicy.template}}"
       path: /{{.Release.Name}}-{{.Values.component.name}}/tmf-api/partyRoleManagement/v4
       developerUI: /{{.Release.Name}}-{{.Values.component.name}}/tmf-api/partyRoleManagement/v4/docs
       port: 8080

--- a/charts/ProductCatalog/values.yaml
+++ b/charts/ProductCatalog/values.yaml
@@ -11,6 +11,34 @@ component:
   publicationDate: 2024-09-17T00:00:00.000Z
   version: "0.0.1"
   storageClassName: default
+  apipolicy:
+    apiKeyVerification:
+      enabled: false
+      location: "header"
+    rateLimit:
+      enabled: false
+      identifier: "IP"
+      limit: "6"
+      interval: "pm"
+    quota:
+      identifier: ""
+      limit: ""
+    OASValidation:
+      requestEnabled: false
+      responseEnabled: false
+      allowUnspecifiedHeaders: false
+      allowUnspecifiedQueryParams: false
+      allowUnspecifiedCookies: false
+    CORS:
+      enabled: false
+      allowCredentials: false
+      allowOrigins: "https://allowed-origin.com, https://allowed-origin2.com"
+      handlePreflightRequests:
+        enabled: false
+        allowHeaders: "Accept, X-Requested-With, Content-Type, Access-Control-Request-Method, Access-Control-Request-Headers"
+        allowMethods: "GET, POST"
+        maxAge: 36000
+    template: ""
   dependentAPIs:
     enabled: false
     rejectUnauthorizedCertificates: false

--- a/charts/ProductInventory/Chart.yaml
+++ b/charts/ProductInventory/Chart.yaml
@@ -15,7 +15,8 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.1 
+version: 1.1.2
+# version: 1.1.2 - added option to pass api  gateway policies through helm chart
 # version: 1.1.1 - Changed to exposedapis from apis
 # version: 1.1.0 - upgrade to v1beta3 spec
 # version: 1.0.0 - baseline version

--- a/charts/ProductInventory/templates/component-productinventory.yaml
+++ b/charts/ProductInventory/templates/component-productinventory.yaml
@@ -24,6 +24,12 @@ spec:
       specification: ["https://raw.githubusercontent.com/tmforum-apis/TMF637_ProductInventory/master/TMF637-ProductInventory-v4.0.0.swagger.json"]
       implementation: {{.Release.Name}}-productinventoryapi
       apiType: openapi
+      apiKeyVerification: {{.Values.component.apipolicy.apiKeyVerification | toYaml | nindent 8}}
+      rateLimit: {{.Values.component.apipolicy.rateLimit | toYaml | nindent 8}}
+      quota: {{.Values.component.apipolicy.quota | toYaml | nindent 8}}
+      OASValidation: {{.Values.component.apipolicy.OASValidation | toYaml | nindent 8}}
+      CORS: {{.Values.component.apipolicy.CORS | toYaml | nindent 8}}
+      template: "{{.Values.component.apipolicy.template}}"
       path: /{{.Release.Name}}-{{.Values.component.name}}/tmf-api/productInventory/v4
       developerUI: /{{.Release.Name}}-{{.Values.component.name}}/tmf-api/productInventory/v4/docs
       port: 8080
@@ -44,6 +50,12 @@ spec:
       specification: ["https://raw.githubusercontent.com/tmforum-apis/TMF669_PartyRole/master/TMF669-PartyRole-v4.0.0.swagger.json"]
       implementation: {{.Release.Name}}-partyroleapi
       apiType: openapi
+      apiKeyVerification: {{.Values.component.apipolicy.apiKeyVerification | toYaml | nindent 8}}
+      rateLimit: {{.Values.component.apipolicy.rateLimit | toYaml | nindent 8}}
+      quota: {{.Values.component.apipolicy.quota | toYaml | nindent 8}}
+      OASValidation: {{.Values.component.apipolicy.OASValidation | toYaml | nindent 8}}
+      CORS: {{.Values.component.apipolicy.CORS | toYaml | nindent 8}}
+      template: "{{.Values.component.apipolicy.template}}"
       path: /{{.Release.Name}}-{{.Values.component.name}}/tmf-api/partyRoleManagement/v4
       developerUI: /{{.Release.Name}}-{{.Values.component.name}}/tmf-api/partyRoleManagement/v4/docs
       port: 8080

--- a/charts/ProductInventory/values.yaml
+++ b/charts/ProductInventory/values.yaml
@@ -10,6 +10,34 @@ component:
   publicationDate: 2023-08-22T00:00:00.000Z
   version: "1.0.1"
   storageClassName: default
+  apipolicy:
+    apiKeyVerification:
+      enabled: false
+      location: "header"
+    rateLimit:
+      enabled: false
+      identifier: "IP"
+      limit: "6"
+      interval: "pm"
+    quota:
+      identifier: ""
+      limit: ""
+    OASValidation:
+      requestEnabled: false
+      responseEnabled: false
+      allowUnspecifiedHeaders: false
+      allowUnspecifiedQueryParams: false
+      allowUnspecifiedCookies: false
+    CORS:
+      enabled: false
+      allowCredentials: false
+      allowOrigins: "https://allowed-origin.com, https://allowed-origin2.com"
+      handlePreflightRequests:
+        enabled: false
+        allowHeaders: "Accept, X-Requested-With, Content-Type, Access-Control-Request-Method, Access-Control-Request-Headers"
+        allowMethods: "GET, POST"
+        maxAge: 36000
+    template: ""
 security:
   controllerRole: Admin
 service:


### PR DESCRIPTION
Added changes to enable api gateway policies to be enabled through helm chart installation.  This includes option to enforce authentication through helm installation. 

@brian-burton This is for issues. - https://github.com/tmforum-oda/oda-canvas/issues/335 and https://github.com/tmforum-oda/reference-example-components/issues/28

