### PR TITLE
Fixed hardcoded release name in MCP API URL.

### DIFF
--- a/charts/ProductCatalog/Chart.yaml
+++ b/charts/ProductCatalog/Chart.yaml
@@ -15,7 +15,8 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.4.0
+version: 1.4.1
+# version: 1.4.1 - Fixed hardcoded release name in MCP API URL.
 # version: 1.4.0 - Updated MCP to Streamable-HTTP.
 # version: 1.3.0 - Added User Roles and Permissions API for dynamic role management.
 # version: 1.2.7 - Updated ProductCatalog component to v1 of the Component spec.

--- a/charts/ProductCatalog/values.yaml
+++ b/charts/ProductCatalog/values.yaml
@@ -61,8 +61,8 @@ api:
 metrics:
   image: lesterthomas/openmetrics:1.0
 mcp:
-  image: lesterthomas/productcatalogmcp:0.13
-  versionLabel: productcatalogmcp-0.13
+  image: lesterthomas/productcatalogmcp:0.14
+  versionLabel: productcatalogmcp-0.14
 partyrole:
   image: lesterthomas/partyroleapi:1.1
   versionLabel: partyroleapi-1.1

--- a/source/ProductCatalog/MCPServerMicroservice/product_catalog_api.py
+++ b/source/ProductCatalog/MCPServerMicroservice/product_catalog_api.py
@@ -30,7 +30,7 @@ logger = logging.getLogger("product-catalog-api")
 if RELEASE_NAME == "local":
     API_URL = "https://localhost/r1-productcatalogmanagement/tmf-api/productCatalogManagement/v4"
 else:
-    API_URL = f"http://{RELEASE_NAME}-prodcatapi:8080/r1-productcatalogmanagement/tmf-api/productCatalogManagement/v4"
+    API_URL = f"http://{RELEASE_NAME}-prodcatapi:8080/{RELEASE_NAME}-productcatalogmanagement/tmf-api/productCatalogManagement/v4"
 logger.info(f"API URL: {API_URL}")
 
 

--- a/source/ProductCatalog/builddockerfile.sh
+++ b/source/ProductCatalog/builddockerfile.sh
@@ -1,7 +1,7 @@
 
 docker buildx build -t "lesterthomas/productcatalogapi:1.3"  --platform "linux/amd64,linux/arm64" -f prodcat-dockerfile . --push
 
-docker buildx build -t "lesterthomas/productcatalogmcp:0.13"  --platform "linux/amd64,linux/arm64" -f prodcat-mcp-dockerfile . --push
+docker buildx build -t "lesterthomas/productcatalogmcp:0.14"  --platform "linux/amd64,linux/arm64" -f prodcat-mcp-dockerfile . --push
 
 docker buildx build -t "lesterthomas/promotionmgmtapi:0.6"  --platform "linux/amd64,linux/arm64" -f promotionmgmt-dockerfile . --push
 


### PR DESCRIPTION
Fixes bug and closes #58 