### PR TITLE
Disable OTLP console logging in values.yaml

### DIFF
--- a/charts/ProductCatalog/values.yaml
+++ b/charts/ProductCatalog/values.yaml
@@ -54,7 +54,7 @@ api:
   versionLabel: productcatalogapi-1.3
   otlp:
     console:
-      enabled: true
+      enabled: false
     protobuffCollector:
       enabled: true
       url: http://observability-opentelemetry-collector.monitoring.svc.cluster.local:4318/v1/traces


### PR DESCRIPTION
Small config change to disable OTLP console logging in values.yaml by default